### PR TITLE
Feature/widget hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
   - [Unit Testing](#unit-test)
     - [Dockerized](#docker)
   - [Profiling](#profiling)
+  - [Hot Reload Widgets](#hot-reload-widgets)
   - [Commit Hooks](#commit-hooks)
 
 - [Roadmap](#roadmap)
@@ -190,6 +191,48 @@ bash profiler.sh -t 10 -o tde-functions.result
 bash profiler.sh -f tests/scripts/full
 
 ```
+
+### Hot Reload Widgets
+
+You can also quickly develop widgets for `tde` this can be done through the `hot-reload-widget.sh` file
+Note that you need to have `inotify-tools` installed.
+If you are using the `TOS` operating system, this script will auto download it for you.
+
+Development using this script is as followed:
+
+1. create a `.lua` file in our example we will use `hello.lua`
+2. The bare minimum for this file should be the following:
+
+```lua
+local wibox = require("wibox")
+return wibox.widget.textbox("hello")
+```
+
+3. Run the script on this file
+
+```bash
+bash scripts/hot-reload-widget.sh hello.lua # replace hello.lua with your file
+```
+
+4. develop your widget/plugin
+
+> NOTE: The file you are developing on needs to return a `wibox.widget` object
+> Otherwise `TDE` doesn't know how to display it
+
+> Second NOTE: the script listens for filesystem event and reloads your widget each time it is changed
+
+Some people don't like that the hot-reloaded widget consumes the entire space.
+If that is the case then use the `-s` option this will make the widget consume 50% of the screen instead of everything. (This issue is not present with multi monitor setups)
+
+#### closing the widget
+
+The closing of the widget is rather strange.
+You must click on the blurred background.
+This is a design choice for many reasons.
+
+Namely:
+
+1. widgets can use keygrabbers thus we don't consume any keys (including Escape) as the widget in development can use those
 
 ### Commit hooks
 

--- a/README.md
+++ b/README.md
@@ -226,13 +226,10 @@ If that is the case then use the `-s` option this will make the widget consume 5
 
 #### closing the widget
 
-The closing of the widget is rather strange.
-You must click on the blurred background.
-This is a design choice for many reasons.
-
-Namely:
-
-1. widgets can use keygrabbers thus we don't consume any keys (including Escape) as the widget in development can use those
+We don't use the Escape key to close the widget
+This is because we would need to consume the Escape key.
+This would result it the underlying widget from not beeing able to capture this event.
+Thus we decided to stricly use the backdrop/close button to close the widget.
 
 ### Commit hooks
 

--- a/scripts/hot-reload-widget.sh
+++ b/scripts/hot-reload-widget.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# MIT License
+# 
+# Copyright (c) 2019 manilarome
+# Copyright (c) 2020 Tom Meyers
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# This file is intended to easily develop TDE widgets
+# you can hot-reload widgets by using this file
+# simply call this script with the lua file as a parameter
+
+# The most basic lua script to develop should look like this:
+#local wibox = require("wibox")
+#return wibox.widget.textbox("Hello")
+
+LUA_FILE=""
+# hw often to reload in seconds
+UPDATE_SPEED="5"
+# reload as fast as possible
+FAST="0"
+
+function print_help(){
+  name=$(basename "$0" .sh)
+  echo -e "$name : OPTIONS [s] <lua file>"
+  echo ""
+  echo -e "$name -s | --side \t\t\tDraw the hot-reload widget to the side of the screen"
+  echo -e "$name -h | --help \t\t\tShow this help message"
+  exit 0
+}
+
+while true; do
+  case "$1" in
+    "-s"|"--side")
+        FAST="1"
+        shift
+    ;;
+    "-h"|"--help")
+        print_help
+        exit 0
+    ;;
+    "")
+     [[ "$LUA_FILE" == "" ]] && print_help
+     break
+    ;;
+    **)
+        LUA_FILE="$1"
+        shift
+    ;;
+  esac
+done
+
+function notify_user(){
+    echo "$1"
+    notify-send "TDE widget hot-reload" "$1"
+}
+
+function notify_user_error(){
+    echo "$1"
+    notify-send "TDE widget hot-reload" "$1" -u "critical"
+}
+
+function check_state(){
+    # check if the widget exists
+    if [[ ! -f "$LUA_FILE" ]]; then
+        notify_user "Please supply a file to hot-reload (must be valid lua)"
+        exit 1
+    fi
+    if [[ ! "$(command -v inotifywait)" ]]; then
+        if [[ ! "$(command -v tos)" ]]; then
+         notify_user "Can't provide hot reload support, please install inotify-tools"
+         exit 1  
+        fi
+        notify_user "Queing inotify-tools using <span  weight='bold'>tos -S inotify-tools</span>\n this is to support hot-reloading"
+        tos -S inotify-tools --noconfirm
+    fi
+    # start dev-widget-hot-reload tde daemon if it doesn't exist yet
+    if [[ "$FAST" == "1" ]]; then
+        tde-client "if not _G.dev_widget_side_view_started then _G.dev_widget_side_view_init() end"
+    else
+        tde-client "if not _G.dev_widget_started then _G.dev_widget_init() end"
+    fi
+
+}
+
+function hot_reload(){
+    file="$(mktemp /tmp/tde_widget_hot_reload_XXXXXXXXX.lua)"
+    cp "$LUA_FILE" "$file"
+    name="$(echo "$file" | sed 's/.lua$//g')"
+
+    if [[ "$FAST" == "1" ]]; then
+        result="$(tde-client "_G.dev_widget_side_view_refresh(\"$name\")")"
+    else
+        result="$(tde-client "_G.dev_widget_refresh(\"$name\")")"
+    fi
+
+    if [[ -n "$result" ]]; then
+        notify_user_error "$(echo "$result" | sed -e 's/^ *[a-z]* "//' -e 's/"$//' -e "s;$file;$LUA_FILE;")"
+    fi
+    notify_user "💡 Hot Reloaded $LUA_FILE"
+    rm "$file"
+}
+
+function listen(){
+    notify_user "Starting listening to filesystem events for $LUA_FILE"
+
+    current_time="$(( $(date +%s) - $UPDATE_SPEED ))"
+
+    hot_reload
+
+    inotifywait -m -e modify "$LUA_FILE" | 
+    while read file op; do
+        # only reload every $UPDATE_SPEED seconds
+        # otherwise we get overloaded with updates
+        # which is taxing on the system
+        if [[ "$(date +%s)" -gt "$(( $current_time + $UPDATE_SPEED ))" || "$FAST" == "1" ]]; then
+            hot_reload
+            current_time="$(date +%s)"
+        fi
+    done
+}
+
+check_state
+listen

--- a/tde/module/dev-widget-update/init.lua
+++ b/tde/module/dev-widget-update/init.lua
@@ -1,4 +1,3 @@
-local file = require "tde.lib-tde.file"
 --[[
 --MIT License
 --
@@ -23,17 +22,17 @@ local file = require "tde.lib-tde.file"
 --OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 --SOFTWARE.
 ]]
-local filehandle = require("tde.lib-tde.file")
-
-print(filehandle.mktemp())
-print(filehandle.mktempdir())
-
-for _ = 1, 10000 do
-    filehandle.exists("/etc/pacman.conf")
-    filehandle.dir_exists("/etc")
+-- this function should get called when the user want to start the development of the widgets
+-- We don't want to load it every time tde start to save resources (since most people don't develop TDE)
+_G.dev_widget_started = false
+_G.dev_widget_init = function()
+    require("module.dev-widget-update.updater")
+    _G.dev_widget_started = true
 end
 
-local name = "/tmp/tde_widget_hot_reload_spAnC1g2k.lua"
+_G.dev_widget_side_view_started = false
 
-print(filehandle.basename(name))
-print(filehandle.dirname(name))
+_G.dev_widget_side_view_init = function()
+    require("module.dev-widget-update.side-updater")
+    _G.dev_widget_side_view_started = true
+end

--- a/tde/module/dev-widget-update/side-updater.lua
+++ b/tde/module/dev-widget-update/side-updater.lua
@@ -33,26 +33,16 @@ local wibox = require("wibox")
 local beautiful = require("beautiful")
 local dpi = beautiful.xresources.apply_dpi
 local filehandle = require("lib-tde.file")
+local icons = require("theme.icons")
+local gears = require("gears")
 
 local m = dpi(10)
+local dev_widget_update_close_height = dpi(60)
 
 -- Create dev_widget on every screen
 screen.connect_signal(
     "request::desktop_decoration",
     function(scr)
-        local backdrop =
-            wibox {
-            ontop = true,
-            screen = scr,
-            visible = false,
-            bg = "#00000000",
-            type = "dock",
-            x = scr.workarea.x + (scr.workarea.width / 2),
-            y = scr.workarea.y,
-            width = scr.geometry.width,
-            height = scr.workarea.height
-        }
-
         local divercence = m * 5
 
         local hub =
@@ -84,32 +74,29 @@ screen.connect_signal(
             end
             view_container:reset()
             view_container:add(require(require_str))
-            backdrop.visible = true
             hub.visible = true
 
             package.path = original_path
         end
 
-        backdrop:buttons(
-            awful.util.table.join(
-                awful.button(
-                    {},
-                    1,
-                    function()
-                        backdrop.visible = false
-                        hub.visible = false
-                        -- remove the widget in the container
-                        -- as it is a developer widget and can cause memory and cpu leaks
-                        view_container:reset()
-                        -- we also perform a garbage collection cycle as we don't know what happend with the widget
-                        collectgarbage("collect")
-                    end
-                )
-            )
-        )
+        local function close_hub()
+            hub.visible = false
+            -- remove the widget in the container
+            -- as it is a developer widget and can cause memory and cpu leaks
+            view_container:reset()
+            -- we also perform a garbage collection cycle as we don't know what happend with the widget
+            collectgarbage("collect")
+        end
+
+        local close = wibox.widget.imagebox(icons.close)
+        close.forced_height = dev_widget_update_close_height
+        close:buttons(gears.table.join(awful.button({}, 1, close_hub)))
+
+        local close_button = wibox.container.place(close, "right")
 
         hub:setup {
-            layout = wibox.layout.flex.vertical,
+            layout = wibox.layout.fixed.vertical,
+            close_button,
             view_container
         }
     end

--- a/tde/module/dev-widget-update/side-updater.lua
+++ b/tde/module/dev-widget-update/side-updater.lua
@@ -1,0 +1,116 @@
+--[[
+--MIT License
+--
+--Copyright (c) 2019 manilarome
+--Copyright (c) 2020 Tom Meyers
+--
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
+--
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
+]]
+-- this file is the "daemon" part that hooks directly into TDE
+-- A helper script should use this file as the following:
+-- tde-client "_G.dev_widget_refresh('the.import.location.of.the.new.widget')"
+-- This will update the widget that is in that file
+-- you can hook this up to a inotify script to auto load the widget :)
+
+local awful = require("awful")
+local wibox = require("wibox")
+local beautiful = require("beautiful")
+local dpi = beautiful.xresources.apply_dpi
+local filehandle = require("lib-tde.file")
+
+local m = dpi(10)
+
+-- Create dev_widget on every screen
+screen.connect_signal(
+    "request::desktop_decoration",
+    function(scr)
+        local backdrop =
+            wibox {
+            ontop = true,
+            screen = scr,
+            visible = false,
+            bg = "#00000000",
+            type = "dock",
+            x = scr.workarea.x + (scr.workarea.width / 2),
+            y = scr.workarea.y,
+            width = scr.geometry.width,
+            height = scr.workarea.height
+        }
+
+        local divercence = m * 5
+
+        local hub =
+            wibox(
+            {
+                ontop = true,
+                visible = false,
+                type = "toolbar",
+                bg = beautiful.background.hue_800,
+                width = (scr.workarea.width / 2) - divercence,
+                height = scr.workarea.height,
+                x = scr.workarea.x + (scr.workarea.width / 2) + divercence,
+                y = scr.workarea.y,
+                screen = scr
+            }
+        )
+
+        local view_container = wibox.layout.flex.vertical()
+        view_container.spacing = m
+
+        _G.dev_widget_side_view_refresh = function(widget_path)
+            local original_path = package.path
+            local require_str = "calendar-widget"
+
+            if widget_path then
+                local dir = filehandle.dirname(widget_path)
+                package.path = dir .. "?.lua;" .. dir .. "?/?.lua;" .. package.path
+                require_str = filehandle.basename(widget_path)
+            end
+            view_container:reset()
+            view_container:add(require(require_str))
+            backdrop.visible = true
+            hub.visible = true
+
+            package.path = original_path
+        end
+
+        backdrop:buttons(
+            awful.util.table.join(
+                awful.button(
+                    {},
+                    1,
+                    function()
+                        backdrop.visible = false
+                        hub.visible = false
+                        -- remove the widget in the container
+                        -- as it is a developer widget and can cause memory and cpu leaks
+                        view_container:reset()
+                        -- we also perform a garbage collection cycle as we don't know what happend with the widget
+                        collectgarbage("collect")
+                    end
+                )
+            )
+        )
+
+        hub:setup {
+            layout = wibox.layout.flex.vertical,
+            view_container
+        }
+    end
+)

--- a/tde/module/dev-widget-update/updater.lua
+++ b/tde/module/dev-widget-update/updater.lua
@@ -33,8 +33,11 @@ local wibox = require("wibox")
 local beautiful = require("beautiful")
 local dpi = beautiful.xresources.apply_dpi
 local filehandle = require("lib-tde.file")
+local icons = require("theme.icons")
+local gears = require("gears")
 
 local m = dpi(10)
+local dev_widget_update_close_height = dpi(60)
 local dev_widget_update_width = dpi(1100)
 local dev_widget_update_height = dpi(900)
 
@@ -100,26 +103,27 @@ screen.connect_signal(
             package.path = original_path
         end
 
-        backdrop:buttons(
-            awful.util.table.join(
-                awful.button(
-                    {},
-                    1,
-                    function()
-                        backdrop.visible = false
-                        hub.visible = false
-                        -- remove the widget in the container
-                        -- as it is a developer widget and can cause memory and cpu leaks
-                        view_container:reset()
-                        -- we also perform a garbage collection cycle as we don't know what happend with the widget
-                        collectgarbage("collect")
-                    end
-                )
-            )
-        )
+        local function close_hub()
+            backdrop.visible = false
+            hub.visible = false
+            -- remove the widget in the container
+            -- as it is a developer widget and can cause memory and cpu leaks
+            view_container:reset()
+            -- we also perform a garbage collection cycle as we don't know what happend with the widget
+            collectgarbage("collect")
+        end
+
+        backdrop:buttons(awful.util.table.join(awful.button({}, 1, close_hub)))
+
+        local close = wibox.widget.imagebox(icons.close)
+        close.forced_height = dev_widget_update_close_height
+        close:buttons(gears.table.join(awful.button({}, 1, close_hub)))
+
+        local close_button = wibox.container.place(close, "right")
 
         hub:setup {
-            layout = wibox.layout.flex.vertical,
+            layout = wibox.layout.fixed.vertical,
+            close_button,
             view_container
         }
     end

--- a/tde/module/dev-widget-update/updater.lua
+++ b/tde/module/dev-widget-update/updater.lua
@@ -1,0 +1,126 @@
+--[[
+--MIT License
+--
+--Copyright (c) 2019 manilarome
+--Copyright (c) 2020 Tom Meyers
+--
+--Permission is hereby granted, free of charge, to any person obtaining a copy
+--of this software and associated documentation files (the "Software"), to deal
+--in the Software without restriction, including without limitation the rights
+--to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--copies of the Software, and to permit persons to whom the Software is
+--furnished to do so, subject to the following conditions:
+--
+--The above copyright notice and this permission notice shall be included in all
+--copies or substantial portions of the Software.
+--
+--THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--SOFTWARE.
+]]
+-- this file is the "daemon" part that hooks directly into TDE
+-- A helper script should use this file as the following:
+-- tde-client "_G.dev_widget_refresh('the.import.location.of.the.new.widget')"
+-- This will update the widget that is in that file
+-- you can hook this up to a inotify script to auto load the widget :)
+
+local awful = require("awful")
+local wibox = require("wibox")
+local beautiful = require("beautiful")
+local dpi = beautiful.xresources.apply_dpi
+local filehandle = require("lib-tde.file")
+
+local m = dpi(10)
+local dev_widget_update_width = dpi(1100)
+local dev_widget_update_height = dpi(900)
+
+-- Create dev_widget on every screen
+screen.connect_signal(
+    "request::desktop_decoration",
+    function(scr)
+        local function get_x_offset()
+            local width = scr.workarea.width
+            return (width - dev_widget_update_width) / 2
+        end
+
+        local function get_y_offset()
+            local height = scr.workarea.height
+            return (height - dev_widget_update_height) / 2
+        end
+
+        local backdrop =
+            wibox {
+            ontop = true,
+            screen = scr,
+            visible = false,
+            bg = "#00000000",
+            type = "dock",
+            x = scr.geometry.x,
+            y = scr.geometry.y,
+            width = scr.geometry.width,
+            height = scr.geometry.height
+        }
+
+        local hub =
+            wibox(
+            {
+                ontop = true,
+                visible = false,
+                type = "toolbar",
+                bg = beautiful.background.hue_800,
+                width = dev_widget_update_width,
+                height = dev_widget_update_height,
+                x = scr.workarea.x + get_x_offset(),
+                y = scr.workarea.y + get_y_offset(),
+                screen = scr
+            }
+        )
+
+        local view_container = wibox.layout.flex.vertical()
+        view_container.spacing = m
+
+        _G.dev_widget_refresh = function(widget_path)
+            local original_path = package.path
+            local require_str = "calendar-widget"
+
+            if widget_path then
+                local dir = filehandle.dirname(widget_path)
+                package.path = dir .. "?.lua;" .. dir .. "?/?.lua;" .. package.path
+                require_str = filehandle.basename(widget_path)
+            end
+            view_container:reset()
+            view_container:add(require(require_str))
+            backdrop.visible = true
+            hub.visible = true
+
+            package.path = original_path
+        end
+
+        backdrop:buttons(
+            awful.util.table.join(
+                awful.button(
+                    {},
+                    1,
+                    function()
+                        backdrop.visible = false
+                        hub.visible = false
+                        -- remove the widget in the container
+                        -- as it is a developer widget and can cause memory and cpu leaks
+                        view_container:reset()
+                        -- we also perform a garbage collection cycle as we don't know what happend with the widget
+                        collectgarbage("collect")
+                    end
+                )
+            )
+        )
+
+        hub:setup {
+            layout = wibox.layout.flex.vertical,
+            view_container
+        }
+    end
+)

--- a/tde/rc.lua
+++ b/tde/rc.lua
@@ -172,6 +172,8 @@ end
 require("module.state")
 require("tutorial")
 
+require("module.dev-widget-update")
+
 require("lib-tde.signals").connect_exit(
   function()
     -- stop current autorun.sh

--- a/tests/profile-scripts/file.lua
+++ b/tests/profile-scripts/file.lua
@@ -1,4 +1,3 @@
-local file = require "tde.lib-tde.file"
 --[[
 --MIT License
 --


### PR DESCRIPTION
This pr enables widget hot reload support

One chance still needs to happen:
Add a big X in the top left corner of the widget hot reload frame.
This should close the dev environment.

Currently you can only close it through clicking outside the border of the widget hot reload frame
This would improve the UX massivly