### PR TITLE
MISC: skip merge commit message checks

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -100,8 +100,18 @@ function print_errors() {
   }
 }
 
+function run_check_if_merge_commit {
+  # skip the entire check if it is a merge commit
+  if echo "$1" | grep -Eq "^Merge .* into .*"; then
+    log "0" "Merge commit"
+    log "0" "Status"
+    exit 0
+  fi
+}
+
 data="$(sed '/^ *#/d' "$1")"
 
+run_check_if_merge_commit "$data"
 run_prepend_commit_msg "$data"
 run_commit_msg_has_description "$data"
 run_commit_msg_first_line_small "$data"


### PR DESCRIPTION
Merge commits don't need to follow the requirments for commit messages
This patch checks to see if a merge commit is happening if so it ommits
the check